### PR TITLE
Add highlighting for article edits

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -169,3 +169,7 @@ table a:not(.btn):hover code,
 code {
     line-height: 1;
 }
+
+.admonition.article-edit {
+    background-color: #FFF3FF;
+}


### PR DESCRIPTION
Using Python Markdown's admonition extension.
