### PR TITLE
Fix link underline disappearing

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -131,7 +131,8 @@ footer:not(.post-info) a:focus {
     text-decoration: none;
 }
 
-footer.post-info a:hover {
+footer.post-info a:hover,
+footer:not(.post-info) a:hover {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
Focused page footer links had no underline when hovered over.
