### PR TITLE
Reduce font size for small displays

### DIFF
--- a/static/css/bootstrap.cosmo-custom.min.css
+++ b/static/css/bootstrap.cosmo-custom.min.css
@@ -313,7 +313,7 @@ select{background:#fff!important}
 .glyphicon-menu-up:before{content:"\e260"}
 *,:after,:before{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 html{font-size:10px;-webkit-tap-highlight-color:rgba(0,0,0,0)}
-body{font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-size:22px;line-height:1.45454545;color:#333;background-color:#fff}
+body{font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-size:17px;line-height:1.41176471;color:#333;background-color:#fff}
 button,input,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}
 a{color:#2780e3;text-decoration:none}
 a:focus,a:hover{color:#165ba8;text-decoration:underline}
@@ -322,28 +322,28 @@ figure{margin:0}
 img{vertical-align:middle}
 .carousel-inner>.item>a>img,.carousel-inner>.item>img,.img-responsive,.thumbnail a>img,.thumbnail>img{display:block;max-width:100%;height:auto}
 .img-rounded{border-radius:0}
-.img-thumbnail{padding:4px;line-height:1.45454545;background-color:#fff;border:1px solid #ddd;border-radius:0;-webkit-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out;display:inline-block;max-width:100%;height:auto}
+.img-thumbnail{padding:4px;line-height:1.41176471;background-color:#fff;border:1px solid #ddd;border-radius:0;-webkit-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out;display:inline-block;max-width:100%;height:auto}
 .img-circle{border-radius:50%}
-hr{margin-top:31px;margin-bottom:31px;border:0;border-top:1px solid #e6e6e6}
+hr{margin-top:24px;margin-bottom:24px;border:0;border-top:1px solid #e6e6e6}
 .sr-only{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);border:0}
 .sr-only-focusable:active,.sr-only-focusable:focus{position:static;width:auto;height:auto;margin:0;overflow:visible;clip:auto}
 [role=button]{cursor:pointer}
 .h1,.h2,.h3,.h4,.h5,.h6,h1,h2,h3,h4,h5,h6{font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-weight:#300;line-height:1.1;color:inherit}
 .h1 .small,.h1 small,.h2 .small,.h2 small,.h3 .small,.h3 small,.h4 .small,.h4 small,.h5 .small,.h5 small,.h6 .small,.h6 small,h1 .small,h1 small,h2 .small,h2 small,h3 .small,h3 small,h4 .small,h4 small,h5 .small,h5 small,h6 .small,h6 small{font-weight:400;line-height:1;color:#999}
-.h1,.h2,.h3,h1,h2,h3{margin-top:31px;margin-bottom:15.5px}
+.h1,.h2,.h3,h1,h2,h3{margin-top:24px;margin-bottom:12px}
 .h1 .small,.h1 small,.h2 .small,.h2 small,.h3 .small,.h3 small,h1 .small,h1 small,h2 .small,h2 small,h3 .small,h3 small{font-size:65%}
-.h4,.h5,.h6,h4,h5,h6{margin-top:15.5px;margin-bottom:15.5px}
+.h4,.h5,.h6,h4,h5,h6{margin-top:12px;margin-bottom:12px}
 .h4 .small,.h4 small,.h5 .small,.h5 small,.h6 .small,.h6 small,h4 .small,h4 small,h5 .small,h5 small,h6 .small,h6 small{font-size:75%}
-.h1,h1{font-size:57px}
-.h2,h2{font-size:47px}
-.h3,h3{font-size:38px}
-.h4,h4{font-size:28px}
-.h5,h5{font-size:22px}
-.h6,h6{font-size:19px}
-p{margin:0 0 15.5px}
-.lead{margin-bottom:31px;font-size:25px;font-weight:300;line-height:1.4}
-@media (min-width:768px){.lead{font-size:33px}}
-.small,small{font-size:86%}
+.h1,h1{font-size:44px}
+.h2,h2{font-size:36px}
+.h3,h3{font-size:29px}
+.h4,h4{font-size:22px}
+.h5,h5{font-size:17px}
+.h6,h6{font-size:15px}
+p{margin:0 0 12px}
+.lead{margin-bottom:24px;font-size:19px;font-weight:300;line-height:1.4}
+@media (min-width:768px){.lead{font-size:25.5px}}
+.small,small{font-size:88%}
 .mark,mark{background-color:#ff7518;padding:.2em}
 .text-left{text-align:left}
 .text-right{text-align:right}
@@ -369,33 +369,33 @@ a.bg-info:hover{background-color:#7e3f9d}
 a.bg-warning:hover{background-color:#e45c00}
 .bg-danger{background-color:#ff0039}
 a.bg-danger:hover{background-color:#cc002e}
-.page-header{padding-bottom:14.5px;margin:62px 0 31px;border-bottom:1px solid #e6e6e6}
-ol,ul{margin-top:0;margin-bottom:15.5px}
+.page-header{padding-bottom:11px;margin:48px 0 24px;border-bottom:1px solid #e6e6e6}
+ol,ul{margin-top:0;margin-bottom:12px}
 ol ol,ol ul,ul ol,ul ul{margin-bottom:0}
 .list-unstyled{padding-left:0;list-style:none}
 .list-inline{padding-left:0;list-style:none;margin-left:-5px}
 .list-inline>li{display:inline-block;padding-left:5px;padding-right:5px}
-dl{margin-top:0;margin-bottom:31px}
-dd,dt{line-height:1.45454545}
+dl{margin-top:0;margin-bottom:24px}
+dd,dt{line-height:1.41176471}
 dt{font-weight:700}
 dd{margin-left:0}
 @media (min-width:768px){.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .dl-horizontal dd{margin-left:180px}}
 abbr[data-original-title],abbr[title]{cursor:help;border-bottom:1px dotted #999}
 .initialism{font-size:90%;text-transform:uppercase}
-blockquote{padding:15.5px 31px;margin:0 0 31px;font-size:27.5px;border-left:5px solid #e6e6e6}
+blockquote{padding:12px 24px;margin:0 0 24px;font-size:21.25px;border-left:5px solid #e6e6e6}
 blockquote ol:last-child,blockquote p:last-child,blockquote ul:last-child{margin-bottom:0}
-blockquote .small,blockquote footer,blockquote small{display:block;font-size:80%;line-height:1.45454545;color:#999}
+blockquote .small,blockquote footer,blockquote small{display:block;font-size:80%;line-height:1.41176471;color:#999}
 blockquote .small:before,blockquote footer:before,blockquote small:before{content:'\2014 \00A0'}
 .blockquote-reverse,blockquote.pull-right{padding-right:15px;padding-left:0;border-right:5px solid #e6e6e6;border-left:0;text-align:right}
 .blockquote-reverse .small:before,.blockquote-reverse footer:before,.blockquote-reverse small:before,blockquote.pull-right .small:before,blockquote.pull-right footer:before,blockquote.pull-right small:before{content:''}
 .blockquote-reverse .small:after,.blockquote-reverse footer:after,.blockquote-reverse small:after,blockquote.pull-right .small:after,blockquote.pull-right footer:after,blockquote.pull-right small:after{content:'\00A0 \2014'}
-address{margin-bottom:31px;font-style:normal;line-height:1.45454545}
+address{margin-bottom:24px;font-style:normal;line-height:1.41176471}
 code,kbd,pre,samp{font-family:Cousine,"Liberation Mono",Menlo,Monaco,Consolas,"Courier New",monospace}
 code{padding:2px 4px;font-size:90%;color:#c7254e;background-color:#f9f2f4;border-radius:0}
 kbd{padding:2px 4px;font-size:90%;color:#fff;background-color:#333;border-radius:0;box-shadow:inset 0 -1px 0 rgba(0,0,0,.25)}
 kbd kbd{padding:0;font-size:100%;font-weight:700;box-shadow:none}
-pre{display:block;padding:15px;margin:0 0 15.5px;font-size:21px;line-height:1.45454545;word-break:break-all;word-wrap:break-word;color:#333;background-color:#f5f5f5;border:1px solid #ccc;border-radius:0}
+pre{display:block;padding:11.5px;margin:0 0 12px;font-size:16px;line-height:1.41176471;word-break:break-all;word-wrap:break-word;color:#333;background-color:#f5f5f5;border:1px solid #ccc;border-radius:0}
 pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border-radius:0}
 .pre-scrollable{max-height:340px;overflow-y:scroll}
 .container,.container-fluid{margin-right:auto;margin-left:auto;padding-left:15px;padding-right:15px}
@@ -615,8 +615,8 @@ pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;backgrou
 table{background-color:rgba(0,0,0,0)}
 caption{padding-top:8px;padding-bottom:8px;color:#999;text-align:left}
 th{text-align:left}
-.table{width:100%;max-width:100%;margin-bottom:31px}
-.table>tbody>tr>td,.table>tbody>tr>th,.table>tfoot>tr>td,.table>tfoot>tr>th,.table>thead>tr>td,.table>thead>tr>th{padding:8px;line-height:1.45454545;vertical-align:top;border-top:1px solid #ddd}
+.table{width:100%;max-width:100%;margin-bottom:24px}
+.table>tbody>tr>td,.table>tbody>tr>th,.table>tfoot>tr>td,.table>tfoot>tr>th,.table>thead>tr>td,.table>thead>tr>th{padding:8px;line-height:1.41176471;vertical-align:top;border-top:1px solid #ddd}
 .table>thead>tr>th{vertical-align:bottom;border-bottom:2px solid #ddd}
 .table>caption+thead>tr:first-child>td,.table>caption+thead>tr:first-child>th,.table>colgroup+thead>tr:first-child>td,.table>colgroup+thead>tr:first-child>th,.table>thead:first-child>tr:first-child>td,.table>thead:first-child>tr:first-child>th{border-top:0}
 .table>tbody+tbody{border-top:2px solid #ddd}
@@ -639,7 +639,7 @@ table td[class*=col-],table th[class*=col-]{position:static;float:none;display:t
 .table>tbody>tr.danger>td,.table>tbody>tr.danger>th,.table>tbody>tr>td.danger,.table>tbody>tr>th.danger,.table>tfoot>tr.danger>td,.table>tfoot>tr.danger>th,.table>tfoot>tr>td.danger,.table>tfoot>tr>th.danger,.table>thead>tr.danger>td,.table>thead>tr.danger>th,.table>thead>tr>td.danger,.table>thead>tr>th.danger{background-color:#ff0039}
 .table-hover>tbody>tr.danger:hover>td,.table-hover>tbody>tr.danger:hover>th,.table-hover>tbody>tr:hover>.danger,.table-hover>tbody>tr>td.danger:hover,.table-hover>tbody>tr>th.danger:hover{background-color:#e60033}
 .table-responsive{overflow-x:auto;min-height:.01%}
-@media screen and (max-width:767px){.table-responsive{width:100%;margin-bottom:23.25px;overflow-y:hidden;-ms-overflow-style:-ms-autohiding-scrollbar;border:1px solid #ddd}
+@media screen and (max-width:767px){.table-responsive{width:100%;margin-bottom:18px;overflow-y:hidden;-ms-overflow-style:-ms-autohiding-scrollbar;border:1px solid #ddd}
 .table-responsive>.table{margin-bottom:0}
 .table-responsive>.table>tbody>tr>td,.table-responsive>.table>tbody>tr>th,.table-responsive>.table>tfoot>tr>td,.table-responsive>.table>tfoot>tr>th,.table-responsive>.table>thead>tr>td,.table-responsive>.table>thead>tr>th{white-space:nowrap}
 .table-responsive>.table-bordered{border:0}
@@ -647,7 +647,7 @@ table td[class*=col-],table th[class*=col-]{position:static;float:none;display:t
 .table-responsive>.table-bordered>tbody>tr>td:last-child,.table-responsive>.table-bordered>tbody>tr>th:last-child,.table-responsive>.table-bordered>tfoot>tr>td:last-child,.table-responsive>.table-bordered>tfoot>tr>th:last-child,.table-responsive>.table-bordered>thead>tr>td:last-child,.table-responsive>.table-bordered>thead>tr>th:last-child{border-right:0}
 .table-responsive>.table-bordered>tbody>tr:last-child>td,.table-responsive>.table-bordered>tbody>tr:last-child>th,.table-responsive>.table-bordered>tfoot>tr:last-child>td,.table-responsive>.table-bordered>tfoot>tr:last-child>th{border-bottom:0}}
 fieldset{padding:0;margin:0;border:0;min-width:0}
-legend{display:block;width:100%;padding:0;margin-bottom:31px;font-size:33px;line-height:inherit;color:#333;border:0;border-bottom:1px solid #e5e5e5}
+legend{display:block;width:100%;padding:0;margin-bottom:24px;font-size:25.5px;line-height:inherit;color:#333;border:0;border-bottom:1px solid #e5e5e5}
 label{display:inline-block;max-width:100%;margin-bottom:5px;font-weight:700}
 input[type=search]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
 input[type=checkbox],input[type=radio]{margin:4px 0 0;line-height:normal}
@@ -655,8 +655,8 @@ input[type=file]{display:block}
 input[type=range]{display:block;width:100%}
 select[multiple],select[size]{height:auto}
 input[type=checkbox]:focus,input[type=file]:focus,input[type=radio]:focus{outline:dotted thin;outline:-webkit-focus-ring-color 5px;outline-offset:-2px}
-output{display:block;padding-top:11px;font-size:22px;line-height:1.45454545;color:#333}
-.form-control{display:block;width:100%;height:53px;padding:10px 18px;font-size:22px;line-height:1.45454545;color:#333;background-color:#fff;background-image:none;border:1px solid #ccc;border-radius:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);box-shadow:inset 0 1px 1px rgba(0,0,0,.075);-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
+output{display:block;padding-top:11px;font-size:17px;line-height:1.41176471;color:#333}
+.form-control{display:block;width:100%;height:46px;padding:10px 18px;font-size:17px;line-height:1.41176471;color:#333;background-color:#fff;background-image:none;border:1px solid #ccc;border-radius:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);box-shadow:inset 0 1px 1px rgba(0,0,0,.075);-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}
 .form-control:focus{border-color:#66afe9;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6)}
 .form-control::-moz-placeholder{color:#999;opacity:1}
 .form-control:-ms-input-placeholder{color:#999}
@@ -665,38 +665,38 @@ output{display:block;padding-top:11px;font-size:22px;line-height:1.45454545;colo
 .form-control[disabled],fieldset[disabled] .form-control{cursor:not-allowed}
 textarea.form-control{height:auto}
 input[type=search]{-webkit-appearance:none}
-@media screen and (-webkit-min-device-pixel-ratio:0){input[type=date],input[type=datetime-local],input[type=month],input[type=time]{line-height:53px}
-.input-group-sm input[type=date],.input-group-sm input[type=datetime-local],.input-group-sm input[type=month],.input-group-sm input[type=time],input[type=date].input-sm,input[type=datetime-local].input-sm,input[type=month].input-sm,input[type=time].input-sm{line-height:40px}
-.input-group-lg input[type=date],.input-group-lg input[type=datetime-local],.input-group-lg input[type=month],.input-group-lg input[type=time],input[type=date].input-lg,input[type=datetime-local].input-lg,input[type=month].input-lg,input[type=time].input-lg{line-height:76px}}
+@media screen and (-webkit-min-device-pixel-ratio:0){input[type=date],input[type=datetime-local],input[type=month],input[type=time]{line-height:46px}
+.input-group-sm input[type=date],.input-group-sm input[type=datetime-local],.input-group-sm input[type=month],.input-group-sm input[type=time],input[type=date].input-sm,input[type=datetime-local].input-sm,input[type=month].input-sm,input[type=time].input-sm{line-height:34px}
+.input-group-lg input[type=date],.input-group-lg input[type=datetime-local],.input-group-lg input[type=month],.input-group-lg input[type=time],input[type=date].input-lg,input[type=datetime-local].input-lg,input[type=month].input-lg,input[type=time].input-lg{line-height:68px}}
 .form-group{margin-bottom:15px}
 .checkbox,.radio{position:relative;display:block;margin-top:10px;margin-bottom:10px}
-.checkbox label,.radio label{min-height:31px;padding-left:20px;margin-bottom:0;font-weight:400;cursor:pointer}
+.checkbox label,.radio label{min-height:24px;padding-left:20px;margin-bottom:0;font-weight:400;cursor:pointer}
 .checkbox input[type=checkbox],.checkbox-inline input[type=checkbox],.radio input[type=radio],.radio-inline input[type=radio]{position:absolute;margin-left:-20px}
 .checkbox+.checkbox,.radio+.radio{margin-top:-5px}
 .checkbox-inline,.radio-inline{position:relative;display:inline-block;padding-left:20px;margin-bottom:0;vertical-align:middle;font-weight:400;cursor:pointer}
 .checkbox-inline+.checkbox-inline,.radio-inline+.radio-inline{margin-top:0;margin-left:10px}
 .checkbox-inline.disabled,.checkbox.disabled label,.radio-inline.disabled,.radio.disabled label,fieldset[disabled] .checkbox label,fieldset[disabled] .checkbox-inline,fieldset[disabled] .radio label,fieldset[disabled] .radio-inline,fieldset[disabled] input[type=checkbox],fieldset[disabled] input[type=radio],input[type=checkbox].disabled,input[type=checkbox][disabled],input[type=radio].disabled,input[type=radio][disabled]{cursor:not-allowed}
-.form-control-static{padding-top:11px;padding-bottom:11px;margin-bottom:0;min-height:53px}
+.form-control-static{padding-top:11px;padding-bottom:11px;margin-bottom:0;min-height:41px}
 .form-control-static.input-lg,.form-control-static.input-sm{padding-left:0;padding-right:0}
-.input-sm{height:40px;padding:5px 10px;font-size:19px;line-height:1.5;border-radius:0}
-select.input-sm{height:40px;line-height:40px}
+.input-sm{height:34px;padding:5px 10px;font-size:15px;line-height:1.5;border-radius:0}
+select.input-sm{height:34px;line-height:34px}
 select[multiple].input-sm,textarea.input-sm{height:auto}
-.form-group-sm .form-control{height:40px;padding:5px 10px;font-size:19px;line-height:1.5;border-radius:0}
-select.form-group-sm .form-control{height:40px;line-height:40px}
+.form-group-sm .form-control{height:34px;padding:5px 10px;font-size:15px;line-height:1.5;border-radius:0}
+select.form-group-sm .form-control{height:34px;line-height:34px}
 select[multiple].form-group-sm .form-control,textarea.form-group-sm .form-control{height:auto}
-.form-group-sm .form-control-static{height:40px;padding:5px 10px;font-size:19px;line-height:1.5;min-height:50px}
-.input-lg{height:76px;padding:18px 30px;font-size:28px;line-height:1.3333333;border-radius:0}
-select.input-lg{height:76px;line-height:76px}
+.form-group-sm .form-control-static{height:34px;padding:5px 10px;font-size:15px;line-height:1.5;min-height:39px}
+.input-lg{height:68px;padding:18px 30px;font-size:22px;line-height:1.3333333;border-radius:0}
+select.input-lg{height:68px;line-height:68px}
 select[multiple].input-lg,textarea.input-lg{height:auto}
-.form-group-lg .form-control{height:76px;padding:18px 30px;font-size:28px;line-height:1.3333333;border-radius:0}
-select.form-group-lg .form-control{height:76px;line-height:76px}
+.form-group-lg .form-control{height:68px;padding:18px 30px;font-size:22px;line-height:1.3333333;border-radius:0}
+select.form-group-lg .form-control{height:68px;line-height:68px}
 select[multiple].form-group-lg .form-control,textarea.form-group-lg .form-control{height:auto}
-.form-group-lg .form-control-static{height:76px;padding:18px 30px;font-size:28px;line-height:1.3333333;min-height:59px}
+.form-group-lg .form-control-static{height:68px;padding:18px 30px;font-size:22px;line-height:1.3333333;min-height:46px}
 .has-feedback{position:relative}
-.has-feedback .form-control{padding-right:66.25px}
-.form-control-feedback{position:absolute;top:0;right:0;z-index:2;display:block;width:53px;height:53px;line-height:53px;text-align:center;pointer-events:none}
-.input-lg+.form-control-feedback{width:76px;height:76px;line-height:76px}
-.input-sm+.form-control-feedback{width:40px;height:40px;line-height:40px}
+.has-feedback .form-control{padding-right:57.5px}
+.form-control-feedback{position:absolute;top:0;right:0;z-index:2;display:block;width:46px;height:46px;line-height:46px;text-align:center;pointer-events:none}
+.input-lg+.form-control-feedback{width:68px;height:68px;line-height:68px}
+.input-sm+.form-control-feedback{width:34px;height:34px;line-height:34px}
 .has-success .checkbox,.has-success .checkbox-inline,.has-success .control-label,.has-success .help-block,.has-success .radio,.has-success .radio-inline,.has-success.checkbox label,.has-success.checkbox-inline label,.has-success.radio label,.has-success.radio-inline label{color:#fff}
 .has-success .form-control{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);box-shadow:inset 0 1px 1px rgba(0,0,0,.075)}
 .has-success .form-control:focus{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 6px #fff;box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 6px #fff}
@@ -709,7 +709,7 @@ select[multiple].form-group-lg .form-control,textarea.form-group-lg .form-contro
 .has-error .form-control{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);box-shadow:inset 0 1px 1px rgba(0,0,0,.075)}
 .has-error .form-control:focus{-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 6px #fff;box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 6px #fff}
 .has-error .input-group-addon{color:#fff;background-color:#ff0039}
-.has-feedback label~.form-control-feedback{top:36px}
+.has-feedback label~.form-control-feedback{top:29px}
 .has-feedback label.sr-only~.form-control-feedback{top:0}
 .help-block{display:block;margin-top:5px;margin-bottom:10px;color:#737373}
 @media (min-width:768px){.form-inline .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}
@@ -724,13 +724,13 @@ select[multiple].form-group-lg .form-control,textarea.form-group-lg .form-contro
 .form-inline .checkbox input[type=checkbox],.form-inline .radio input[type=radio]{position:relative;margin-left:0}
 .form-inline .has-feedback .form-control-feedback{top:0}}
 .form-horizontal .checkbox,.form-horizontal .checkbox-inline,.form-horizontal .radio,.form-horizontal .radio-inline{margin-top:0;margin-bottom:0;padding-top:11px}
-.form-horizontal .checkbox,.form-horizontal .radio{min-height:42px}
+.form-horizontal .checkbox,.form-horizontal .radio{min-height:35px}
 .form-horizontal .form-group{margin-left:-15px;margin-right:-15px}
 @media (min-width:768px){.form-horizontal .control-label{text-align:right;margin-bottom:0;padding-top:11px}}
 .form-horizontal .has-feedback .form-control-feedback{right:15px}
 @media (min-width:768px){.form-horizontal .form-group-lg .control-label{padding-top:24.1px}}
 @media (min-width:768px){.form-horizontal .form-group-sm .control-label{padding-top:6px}}
-.btn{display:inline-block;margin-bottom:0;font-weight:400;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;background-image:none;border:1px solid transparent;white-space:nowrap;padding:10px 18px;font-size:22px;line-height:1.45454545;border-radius:0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+.btn{display:inline-block;margin-bottom:0;font-weight:400;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;background-image:none;border:1px solid transparent;white-space:nowrap;padding:10px 18px;font-size:17px;line-height:1.41176471;border-radius:0;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .btn.active.focus,.btn.active:focus,.btn.focus,.btn:active.focus,.btn:active:focus,.btn:focus{outline:dotted thin;outline:-webkit-focus-ring-color 5px;outline-offset:-2px}
 .btn.focus,.btn:focus,.btn:hover{color:#fff;text-decoration:none}
 .btn.active,.btn:active{outline:0;background-image:none;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,.125);box-shadow:inset 0 3px 5px rgba(0,0,0,.125)}
@@ -770,9 +770,9 @@ select[multiple].form-group-lg .form-control,textarea.form-group-lg .form-contro
 .btn-link,.btn-link:active,.btn-link:focus,.btn-link:hover{border-color:transparent}
 .btn-link:focus,.btn-link:hover{color:#165ba8;text-decoration:underline;background-color:transparent}
 .btn-link[disabled]:focus,.btn-link[disabled]:hover,fieldset[disabled] .btn-link:focus,fieldset[disabled] .btn-link:hover{color:#999;text-decoration:none}
-.btn-group-lg>.btn,.btn-lg{padding:18px 30px;font-size:28px;line-height:1.3333333;border-radius:0}
-.btn-group-sm>.btn,.btn-sm{padding:5px 10px;font-size:19px;line-height:1.5;border-radius:0}
-.btn-group-xs>.btn,.btn-xs{padding:1px 5px;font-size:19px;line-height:1.5;border-radius:0}
+.btn-group-lg>.btn,.btn-lg{padding:18px 30px;font-size:22px;line-height:1.3333333;border-radius:0}
+.btn-group-sm>.btn,.btn-sm{padding:5px 10px;font-size:15px;line-height:1.5;border-radius:0}
+.btn-group-xs>.btn,.btn-xs{padding:1px 5px;font-size:15px;line-height:1.5;border-radius:0}
 .btn-block{display:block;width:100%}
 .btn-block+.btn-block{margin-top:5px}
 input[type=button].btn-block,input[type=reset].btn-block,input[type=submit].btn-block{width:100%}
@@ -786,10 +786,10 @@ tbody.collapse.in{display:table-row-group}
 .caret{display:inline-block;width:0;height:0;margin-left:2px;vertical-align:middle;border-top:4px dashed;border-right:4px solid transparent;border-left:4px solid transparent}
 .dropdown,.dropup{position:relative}
 .dropdown-toggle:focus{outline:0}
-.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;list-style:none;font-size:22px;text-align:left;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,.15);border-radius:0;-webkit-box-shadow:0 6px 12px rgba(0,0,0,.175);box-shadow:0 6px 12px rgba(0,0,0,.175);background-clip:padding-box}
+.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;list-style:none;font-size:17px;text-align:left;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,.15);border-radius:0;-webkit-box-shadow:0 6px 12px rgba(0,0,0,.175);box-shadow:0 6px 12px rgba(0,0,0,.175);background-clip:padding-box}
 .dropdown-menu.pull-right{right:0;left:auto}
-.dropdown-menu .divider{height:1px;margin:14.5px 0;overflow:hidden;background-color:#e5e5e5}
-.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:400;line-height:1.45454545;color:#333;white-space:nowrap}
+.dropdown-menu .divider{height:1px;margin:11px 0;overflow:hidden;background-color:#e5e5e5}
+.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:400;line-height:1.41176471;color:#333;white-space:nowrap}
 .dropdown-menu>li>a:focus,.dropdown-menu>li>a:hover{text-decoration:none;color:#fff;background-color:#2780e3}
 .dropdown-menu>.active>a,.dropdown-menu>.active>a:focus,.dropdown-menu>.active>a:hover{color:#fff;text-decoration:none;outline:0;background-color:#2780e3}
 .dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:focus,.dropdown-menu>.disabled>a:hover{color:#999}
@@ -798,7 +798,7 @@ tbody.collapse.in{display:table-row-group}
 .open>a{outline:0}
 .dropdown-menu-right{left:auto;right:0}
 .dropdown-menu-left{left:0;right:auto}
-.dropdown-header{display:block;padding:3px 20px;font-size:19px;line-height:1.45454545;color:#999;white-space:nowrap}
+.dropdown-header{display:block;padding:3px 20px;font-size:15px;line-height:1.41176471;color:#999;white-space:nowrap}
 .dropdown-backdrop{position:fixed;left:0;right:0;bottom:0;top:0;z-index:990}
 .pull-right>.dropdown-menu{right:0;left:auto}
 .dropup .caret,.navbar-fixed-bottom .dropdown .caret{border-top:0;border-bottom:4px solid;content:""}
@@ -845,18 +845,18 @@ tbody.collapse.in{display:table-row-group}
 .input-group{position:relative;display:table;border-collapse:separate}
 .input-group[class*=col-]{float:none;padding-left:0;padding-right:0}
 .input-group .form-control{position:relative;z-index:2;float:left;width:100%;margin-bottom:0}
-.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:76px;padding:18px 30px;font-size:28px;line-height:1.3333333;border-radius:0}
-select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:76px;line-height:76px}
+.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:68px;padding:18px 30px;font-size:22px;line-height:1.3333333;border-radius:0}
+select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:68px;line-height:68px}
 select[multiple].input-group-lg>.form-control,select[multiple].input-group-lg>.input-group-addon,select[multiple].input-group-lg>.input-group-btn>.btn,textarea.input-group-lg>.form-control,textarea.input-group-lg>.input-group-addon,textarea.input-group-lg>.input-group-btn>.btn{height:auto}
-.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:40px;padding:5px 10px;font-size:19px;line-height:1.5;border-radius:0}
-select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:40px;line-height:40px}
+.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:34px;padding:5px 10px;font-size:15px;line-height:1.5;border-radius:0}
+select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:34px;line-height:34px}
 select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.input-group-addon,select[multiple].input-group-sm>.input-group-btn>.btn,textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon,textarea.input-group-sm>.input-group-btn>.btn{height:auto}
 .input-group .form-control,.input-group-addon,.input-group-btn{display:table-cell}
 .input-group .form-control:not(:first-child):not(:last-child),.input-group-addon:not(:first-child):not(:last-child),.input-group-btn:not(:first-child):not(:last-child){border-radius:0}
 .input-group-addon,.input-group-btn{width:1%;white-space:nowrap;vertical-align:middle}
-.input-group-addon{padding:10px 18px;font-size:22px;font-weight:400;line-height:1;color:#333;text-align:center;background-color:#e6e6e6;border:1px solid #ccc;border-radius:0}
-.input-group-addon.input-sm{padding:5px 10px;font-size:19px;border-radius:0}
-.input-group-addon.input-lg{padding:18px 30px;font-size:28px;border-radius:0}
+.input-group-addon{padding:10px 18px;font-size:17px;font-weight:400;line-height:1;color:#333;text-align:center;background-color:#e6e6e6;border:1px solid #ccc;border-radius:0}
+.input-group-addon.input-sm{padding:5px 10px;font-size:15px;border-radius:0}
+.input-group-addon.input-lg{padding:18px 30px;font-size:22px;border-radius:0}
 .input-group-addon input[type=checkbox],.input-group-addon input[type=radio]{margin-top:0}
 .input-group .form-control:first-child,.input-group-addon:first-child,.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group>.btn,.input-group-btn:first-child>.dropdown-toggle,.input-group-btn:last-child>.btn-group:not(:last-child)>.btn,.input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle){border-bottom-right-radius:0;border-top-right-radius:0}
 .input-group-addon:first-child{border-right:0}
@@ -875,11 +875,11 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .nav>li.disabled>a{color:#999}
 .nav>li.disabled>a:focus,.nav>li.disabled>a:hover{color:#999;text-decoration:none;background-color:transparent;cursor:not-allowed}
 .nav .open>a,.nav .open>a:focus,.nav .open>a:hover{background-color:#e6e6e6;border-color:#2780e3}
-.nav .nav-divider{height:1px;margin:14.5px 0;overflow:hidden;background-color:#e5e5e5}
+.nav .nav-divider{height:1px;margin:11px 0;overflow:hidden;background-color:#e5e5e5}
 .nav>li>a>img{max-width:none}
 .nav-tabs{border-bottom:1px solid #ddd}
 .nav-tabs>li{float:left;margin-bottom:-1px}
-.nav-tabs>li>a{margin-right:2px;line-height:1.45454545;border:1px solid transparent;border-radius:0}
+.nav-tabs>li>a{margin-right:2px;line-height:1.41176471;border:1px solid transparent;border-radius:0}
 .nav-tabs>li>a:hover{border-color:#e6e6e6 #e6e6e6 #ddd}
 .nav-tabs>li.active>a,.nav-tabs>li.active>a:focus,.nav-tabs>li.active>a:hover{color:#555;background-color:#fff;border:1px solid #ddd;border-bottom-color:transparent;cursor:default}
 .nav-tabs.nav-justified{width:100%;border-bottom:0}
@@ -911,7 +911,7 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .tab-content>.tab-pane{display:none}
 .tab-content>.active{display:block}
 .nav-tabs .dropdown-menu{margin-top:-1px;border-top-right-radius:0;border-top-left-radius:0}
-.navbar{position:relative;min-height:50px;margin-bottom:31px;border:1px solid transparent}
+.navbar{position:relative;min-height:50px;margin-bottom:24px;border:1px solid transparent}
 @media (min-width:768px){.navbar{border-radius:0}}
 @media (min-width:768px){.navbar-header{float:left}}
 .navbar-collapse{overflow-x:visible;padding-right:15px;padding-left:15px;border-top:1px solid transparent;box-shadow:inset 0 1px 0 rgba(255,255,255,.1);-webkit-overflow-scrolling:touch}
@@ -930,7 +930,7 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 @media (min-width:768px){.navbar-fixed-bottom,.navbar-fixed-top{border-radius:0}}
 .navbar-fixed-top{top:0;border-width:0 0 1px}
 .navbar-fixed-bottom{bottom:0;margin-bottom:0;border-width:1px 0 0}
-.navbar-brand{float:left;padding:9.5px 15px;font-size:28px;line-height:31px;height:50px}
+.navbar-brand{float:left;padding:13px 15px;font-size:22px;line-height:24px;height:50px}
 .navbar-brand:focus,.navbar-brand:hover{text-decoration:none}
 .navbar-brand>img{display:block}
 @media (min-width:768px){.navbar>.container .navbar-brand,.navbar>.container-fluid .navbar-brand{margin-left:-15px}}
@@ -939,16 +939,16 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .navbar-toggle .icon-bar{display:block;width:22px;height:2px;border-radius:1px}
 .navbar-toggle .icon-bar+.icon-bar{margin-top:4px}
 @media (min-width:768px){.navbar-toggle{display:none}}
-.navbar-nav{margin:4.75px -15px}
-.navbar-nav>li>a{padding-top:10px;padding-bottom:10px;line-height:31px}
+.navbar-nav{margin:6.5px -15px}
+.navbar-nav>li>a{padding-top:10px;padding-bottom:10px;line-height:24px}
 @media (max-width:767px){.navbar-nav .open .dropdown-menu{position:static;float:none;width:auto;margin-top:0;background-color:transparent;border:0;box-shadow:none}
 .navbar-nav .open .dropdown-menu .dropdown-header,.navbar-nav .open .dropdown-menu>li>a{padding:5px 15px 5px 25px}
-.navbar-nav .open .dropdown-menu>li>a{line-height:31px}
+.navbar-nav .open .dropdown-menu>li>a{line-height:24px}
 .navbar-nav .open .dropdown-menu>li>a:focus,.navbar-nav .open .dropdown-menu>li>a:hover{background-image:none}}
 @media (min-width:768px){.navbar-nav{float:left;margin:0}
 .navbar-nav>li{float:left}
-.navbar-nav>li>a{padding-top:9.5px;padding-bottom:9.5px}}
-.navbar-form{margin:-1.5px -15px;padding:10px 15px;border-top:1px solid transparent;border-bottom:1px solid transparent;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,.1),0 1px 0 rgba(255,255,255,.1);box-shadow:inset 0 1px 0 rgba(255,255,255,.1),0 1px 0 rgba(255,255,255,.1)}
+.navbar-nav>li>a{padding-top:13px;padding-bottom:13px}}
+.navbar-form{margin:2px -15px;padding:10px 15px;border-top:1px solid transparent;border-bottom:1px solid transparent;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,.1),0 1px 0 rgba(255,255,255,.1);box-shadow:inset 0 1px 0 rgba(255,255,255,.1),0 1px 0 rgba(255,255,255,.1)}
 @media (min-width:768px){.navbar-form .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}
 .navbar-form .form-control{display:inline-block;width:auto;vertical-align:middle}
 .navbar-form .form-control-static{display:inline-block}
@@ -965,10 +965,10 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 @media (min-width:768px){.navbar-form{width:auto;border:0;margin-left:0;margin-right:0;padding-top:0;padding-bottom:0;-webkit-box-shadow:none;box-shadow:none}}
 .navbar-nav>li>.dropdown-menu{margin-top:0;border-top-right-radius:0;border-top-left-radius:0}
 .navbar-fixed-bottom .navbar-nav>li>.dropdown-menu{margin-bottom:0;border-radius:0}
-.navbar-btn{margin-top:-1.5px;margin-bottom:-1.5px}
-.navbar-btn.btn-sm{margin-top:5px;margin-bottom:5px}
+.navbar-btn{margin-top:2px;margin-bottom:2px}
+.navbar-btn.btn-sm{margin-top:8px;margin-bottom:8px}
 .navbar-btn.btn-xs{margin-top:14px;margin-bottom:14px}
-.navbar-text{margin-top:9.5px;margin-bottom:9.5px}
+.navbar-text{margin-top:13px;margin-bottom:13px}
 @media (min-width:768px){.navbar-text{float:left;margin-left:15px;margin-right:15px}}
 @media (min-width:768px){.navbar-left{float:left!important}
 .navbar-right{float:right!important;margin-right:-15px}
@@ -1006,25 +1006,25 @@ select[multiple].input-group-sm>.form-control,select[multiple].input-group-sm>.i
 .navbar-inverse .navbar-nav .open .dropdown-menu>.active>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:focus,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:focus,.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:hover{color:#fff;background-color:#1967be}
 .navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:focus,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:hover{color:#fff;background-color:rgba(0,0,0,0)}}
 .navbar-inverse .btn-link,.navbar-inverse .btn-link:focus,.navbar-inverse .btn-link:hover,.navbar-inverse .btn-link[disabled]:focus,.navbar-inverse .btn-link[disabled]:hover,.navbar-inverse .navbar-link,.navbar-inverse .navbar-link:hover,fieldset[disabled] .navbar-inverse .btn-link:focus,fieldset[disabled] .navbar-inverse .btn-link:hover{color:#fff}
-.breadcrumb{padding:8px 15px;margin-bottom:31px;list-style:none;background-color:#f5f5f5;border-radius:0}
+.breadcrumb{padding:8px 15px;margin-bottom:24px;list-style:none;background-color:#f5f5f5;border-radius:0}
 .breadcrumb>li{display:inline-block}
 .breadcrumb>li+li:before{content:"/\00a0";padding:0 5px;color:#ccc}
 .breadcrumb>.active{color:#999}
-.pagination{display:inline-block;padding-left:0;margin:31px 0;border-radius:0}
+.pagination{display:inline-block;padding-left:0;margin:24px 0;border-radius:0}
 .pagination>li{display:inline}
-.pagination>li>a,.pagination>li>span{position:relative;float:left;padding:10px 18px;line-height:1.45454545;text-decoration:none;color:#323232;background-color:#fff;border:1px solid #ddd;margin-left:-1px}
+.pagination>li>a,.pagination>li>span{position:relative;float:left;padding:10px 18px;line-height:1.41176471;text-decoration:none;color:#2780e3;background-color:#fff;border:1px solid #ddd;margin-left:-1px}
 .pagination>li:first-child>a,.pagination>li:first-child>span{margin-left:0;border-bottom-left-radius:0;border-top-left-radius:0}
 .pagination>li:last-child>a,.pagination>li:last-child>span{border-bottom-right-radius:0;border-top-right-radius:0}
-.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#000;background-color:#e6e6e6;border-color:#ddd}
+.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#165ba8;background-color:#e6e6e6;border-color:#ddd}
 .pagination>.active>a,.pagination>.active>a:focus,.pagination>.active>a:hover,.pagination>.active>span,.pagination>.active>span:focus,.pagination>.active>span:hover{z-index:2;color:#999;background-color:#f5f5f5;border-color:#ddd;cursor:default}
 .pagination>.disabled>a,.pagination>.disabled>a:focus,.pagination>.disabled>a:hover,.pagination>.disabled>span,.pagination>.disabled>span:focus,.pagination>.disabled>span:hover{color:#999;background-color:#fff;border-color:#ddd;cursor:not-allowed}
-.pagination-lg>li>a,.pagination-lg>li>span{padding:18px 30px;font-size:28px}
+.pagination-lg>li>a,.pagination-lg>li>span{padding:18px 30px;font-size:22px}
 .pagination-lg>li:first-child>a,.pagination-lg>li:first-child>span{border-bottom-left-radius:0;border-top-left-radius:0}
 .pagination-lg>li:last-child>a,.pagination-lg>li:last-child>span{border-bottom-right-radius:0;border-top-right-radius:0}
-.pagination-sm>li>a,.pagination-sm>li>span{padding:5px 10px;font-size:19px}
+.pagination-sm>li>a,.pagination-sm>li>span{padding:5px 10px;font-size:15px}
 .pagination-sm>li:first-child>a,.pagination-sm>li:first-child>span{border-bottom-left-radius:0;border-top-left-radius:0}
 .pagination-sm>li:last-child>a,.pagination-sm>li:last-child>span{border-bottom-right-radius:0;border-top-right-radius:0}
-.pager{padding-left:0;margin:31px 0;list-style:none;text-align:center}
+.pager{padding-left:0;margin:24px 0;list-style:none;text-align:center}
 .pager li{display:inline}
 .pager li>a,.pager li>span{display:inline-block;padding:5px 14px;background-color:#fff;border:1px solid #ddd;border-radius:0}
 .pager li>a:focus,.pager li>a:hover{text-decoration:none;background-color:#e6e6e6}
@@ -1047,7 +1047,7 @@ a.label:focus,a.label:hover{color:#fff;text-decoration:none;cursor:pointer}
 .label-warning[href]:focus,.label-warning[href]:hover{background-color:#e45c00}
 .label-danger{background-color:#ff0039}
 .label-danger[href]:focus,.label-danger[href]:hover{background-color:#cc002e}
-.badge{display:inline-block;min-width:10px;padding:3px 7px;font-size:19px;font-weight:700;color:#fff;line-height:1;vertical-align:baseline;white-space:nowrap;text-align:center;background-color:#2780e3;border-radius:10px}
+.badge{display:inline-block;min-width:10px;padding:3px 7px;font-size:15px;font-weight:700;color:#fff;line-height:1;vertical-align:baseline;white-space:nowrap;text-align:center;background-color:#2780e3;border-radius:10px}
 .badge:empty{display:none}
 .btn .badge{position:relative;top:-1px}
 .btn-group-xs>.btn .badge,.btn-xs .badge{top:0;padding:1px 5px}
@@ -1058,18 +1058,18 @@ a.badge:focus,a.badge:hover{color:#fff;text-decoration:none;cursor:pointer}
 .nav-pills>li>a>.badge{margin-left:3px}
 .jumbotron{padding:30px 15px;margin-bottom:30px;color:inherit;background-color:#e6e6e6}
 .jumbotron .h1,.jumbotron h1{color:inherit}
-.jumbotron p{margin-bottom:15px;font-size:33px;font-weight:200}
+.jumbotron p{margin-bottom:15px;font-size:26px;font-weight:200}
 .jumbotron>hr{border-top-color:#ccc}
 .container .jumbotron,.container-fluid .jumbotron{border-radius:0}
 .jumbotron .container{max-width:100%}
 @media screen and (min-width:768px){.jumbotron{padding:48px 0}
 .container .jumbotron,.container-fluid .jumbotron{padding-left:60px;padding-right:60px}
-.jumbotron .h1,.jumbotron h1{font-size:99px}}
-.thumbnail{display:block;padding:4px;margin-bottom:31px;line-height:1.45454545;background-color:#fff;border:1px solid #ddd;border-radius:0;-webkit-transition:border .2s ease-in-out;-o-transition:border .2s ease-in-out;transition:border .2s ease-in-out}
+.jumbotron .h1,.jumbotron h1{font-size:76.5px}}
+.thumbnail{display:block;padding:4px;margin-bottom:24px;line-height:1.41176471;background-color:#fff;border:1px solid #ddd;border-radius:0;-webkit-transition:border .2s ease-in-out;-o-transition:border .2s ease-in-out;transition:border .2s ease-in-out}
 .thumbnail a>img,.thumbnail>img{margin-left:auto;margin-right:auto}
 a.thumbnail.active,a.thumbnail:focus,a.thumbnail:hover{border-color:#2780e3}
 .thumbnail .caption{padding:9px;color:#333}
-.alert{padding:15px;margin-bottom:31px;border-radius:0}
+.alert{padding:15px;margin-bottom:24px;border-radius:0}
 .alert h4{margin-top:0;color:inherit}
 .alert .alert-link{font-weight:700}
 .alert>p,.alert>ul{margin-bottom:0}
@@ -1092,8 +1092,8 @@ a.thumbnail.active,a.thumbnail:focus,a.thumbnail:hover{border-color:#2780e3}
 to{background-position:0 0}}
 @keyframes progress-bar-stripes{from{background-position:40px 0}
 to{background-position:0 0}}
-.progress{overflow:hidden;margin-bottom:31px;background-color:#ccc;border-radius:0}
-.progress-bar{float:left;width:0;height:100%;font-size:19px;line-height:31px;color:#fff;text-align:center;background-color:#2780e3;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,.15);-webkit-transition:width .6s ease;-o-transition:width .6s ease;transition:width .6s ease}
+.progress{overflow:hidden;margin-bottom:24px;background-color:#ccc;border-radius:0}
+.progress-bar{float:left;width:0;height:100%;font-size:15px;line-height:24px;color:#fff;text-align:center;background-color:#2780e3;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,.15);-webkit-transition:width .6s ease;-o-transition:width .6s ease;transition:width .6s ease}
 .progress-bar-striped,.progress-striped .progress-bar{background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,.15)25%,transparent 25%,transparent 50%,rgba(255,255,255,.15)50%,rgba(255,255,255,.15)75%,transparent 75%,transparent);background-image:-o-linear-gradient(45deg,rgba(255,255,255,.15)25%,transparent 25%,transparent 50%,rgba(255,255,255,.15)50%,rgba(255,255,255,.15)75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,.15)25%,transparent 25%,transparent 50%,rgba(255,255,255,.15)50%,rgba(255,255,255,.15)75%,transparent 75%,transparent);background-size:40px 40px}
 .progress-bar.active,.progress.active .progress-bar{-webkit-animation:progress-bar-stripes 2s linear infinite;-o-animation:progress-bar-stripes 2s linear infinite;animation:progress-bar-stripes 2s linear infinite}
 .progress-bar-success{background-color:#3fb618}
@@ -1151,11 +1151,11 @@ a.list-group-item-danger:focus,a.list-group-item-danger:hover{color:#fff;backgro
 a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-group-item-danger.active:hover{color:#fff;border-color:#fff}
 .list-group-item-heading{margin-top:0;margin-bottom:5px}
 .list-group-item-text{margin-bottom:0;line-height:1.3}
-.panel{margin-bottom:31px;background-color:#fff;border:1px solid transparent;border-radius:0;-webkit-box-shadow:0 1px 1px rgba(0,0,0,.05);box-shadow:0 1px 1px rgba(0,0,0,.05)}
+.panel{margin-bottom:24px;background-color:#fff;border:1px solid transparent;border-radius:0;-webkit-box-shadow:0 1px 1px rgba(0,0,0,.05);box-shadow:0 1px 1px rgba(0,0,0,.05)}
 .panel-body{padding:15px}
 .panel-heading{padding:10px 15px;border-bottom:1px solid transparent}
 .panel-heading>.dropdown .dropdown-toggle{color:inherit}
-.panel-title{margin-top:0;margin-bottom:0;font-size:25px;color:inherit}
+.panel-title{margin-top:0;margin-bottom:0;font-size:20px;color:inherit}
 .panel-title>.small,.panel-title>.small>a,.panel-title>a,.panel-title>small,.panel-title>small>a{color:inherit}
 .panel-footer{padding:10px 15px;background-color:#f5f5f5;border-top:1px solid #ddd;border-bottom-right-radius:-1;border-bottom-left-radius:-1}
 .panel>.list-group,.panel>.panel-collapse>.list-group{margin-bottom:0}
@@ -1180,7 +1180,7 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
 .panel>.table-bordered>tbody>tr>td:last-child,.panel>.table-bordered>tbody>tr>th:last-child,.panel>.table-bordered>tfoot>tr>td:last-child,.panel>.table-bordered>tfoot>tr>th:last-child,.panel>.table-bordered>thead>tr>td:last-child,.panel>.table-bordered>thead>tr>th:last-child,.panel>.table-responsive>.table-bordered>tbody>tr>td:last-child,.panel>.table-responsive>.table-bordered>tbody>tr>th:last-child,.panel>.table-responsive>.table-bordered>tfoot>tr>td:last-child,.panel>.table-responsive>.table-bordered>tfoot>tr>th:last-child,.panel>.table-responsive>.table-bordered>thead>tr>td:last-child,.panel>.table-responsive>.table-bordered>thead>tr>th:last-child{border-right:0}
 .panel>.table-bordered>tbody>tr:first-child>td,.panel>.table-bordered>tbody>tr:first-child>th,.panel>.table-bordered>tbody>tr:last-child>td,.panel>.table-bordered>tbody>tr:last-child>th,.panel>.table-bordered>tfoot>tr:last-child>td,.panel>.table-bordered>tfoot>tr:last-child>th,.panel>.table-bordered>thead>tr:first-child>td,.panel>.table-bordered>thead>tr:first-child>th,.panel>.table-responsive>.table-bordered>tbody>tr:first-child>td,.panel>.table-responsive>.table-bordered>tbody>tr:first-child>th,.panel>.table-responsive>.table-bordered>tbody>tr:last-child>td,.panel>.table-responsive>.table-bordered>tbody>tr:last-child>th,.panel>.table-responsive>.table-bordered>tfoot>tr:last-child>td,.panel>.table-responsive>.table-bordered>tfoot>tr:last-child>th,.panel>.table-responsive>.table-bordered>thead>tr:first-child>td,.panel>.table-responsive>.table-bordered>thead>tr:first-child>th{border-bottom:0}
 .panel>.table-responsive{border:0;margin-bottom:0}
-.panel-group{margin-bottom:31px}
+.panel-group{margin-bottom:24px}
 .panel-group .panel{margin-bottom:0;border-radius:0}
 .panel-group .panel+.panel{margin-top:5px}
 .panel-group .panel-heading{border-bottom:0}
@@ -1225,7 +1225,7 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
 .well blockquote{border-color:#ddd;border-color:rgba(0,0,0,.15)}
 .well-lg{padding:24px;border-radius:0}
 .well-sm{padding:9px;border-radius:0}
-.close{float:right;font-size:33px;font-weight:700;line-height:1;color:#fff;filter:alpha(opacity=20)}
+.close{float:right;font-size:25.5px;font-weight:700;line-height:1;color:#fff;filter:alpha(opacity=20)}
 .close:focus,.close:hover{color:#fff;text-decoration:none;cursor:pointer;filter:alpha(opacity=50)}
 button.close{padding:0;cursor:pointer;background:0 0;border:0;-webkit-appearance:none}
 .modal-open{overflow:hidden}
@@ -1238,9 +1238,9 @@ button.close{padding:0;cursor:pointer;background:0 0;border:0;-webkit-appearance
 .modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;background-color:#000}
 .modal-backdrop.fade{opacity:0;filter:alpha(opacity=0)}
 .modal-backdrop.in{opacity:.5;filter:alpha(opacity=50)}
-.modal-header{padding:15px;border-bottom:1px solid #e5e5e5;min-height:16.45px}
+.modal-header{padding:15px;border-bottom:1px solid #e5e5e5;min-height:16.41px}
 .modal-header .close{margin-top:-2px}
-.modal-title{margin:0;line-height:1.45454545}
+.modal-title{margin:0;line-height:1.41176471}
 .modal-body{position:relative;padding:20px}
 .modal-footer{padding:20px;text-align:right;border-top:1px solid #e5e5e5}
 .modal-footer .btn+.btn{margin-left:5px;margin-bottom:0}
@@ -1251,7 +1251,7 @@ button.close{padding:0;cursor:pointer;background:0 0;border:0;-webkit-appearance
 .modal-content{-webkit-box-shadow:0 5px 15px rgba(0,0,0,.5);box-shadow:0 5px 15px rgba(0,0,0,.5)}
 .modal-sm{width:300px}}
 @media (min-width:992px){.modal-lg{width:900px}}
-.tooltip{position:absolute;z-index:1070;display:block;font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-size:19px;font-weight:400;line-height:1.4;opacity:0;filter:alpha(opacity=0)}
+.tooltip{position:absolute;z-index:1070;display:block;font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-size:15px;font-weight:400;line-height:1.4;opacity:0;filter:alpha(opacity=0)}
 .tooltip.in{opacity:.9;filter:alpha(opacity=90)}
 .tooltip.top{margin-top:-3px;padding:5px 0}
 .tooltip.right{margin-left:3px;padding:0 5px}
@@ -1267,12 +1267,12 @@ button.close{padding:0;cursor:pointer;background:0 0;border:0;-webkit-appearance
 .tooltip.bottom .tooltip-arrow{top:0;left:50%;margin-left:-5px;border-width:0 5px 5px;border-bottom-color:#000}
 .tooltip.bottom-left .tooltip-arrow{top:0;right:5px;margin-top:-5px;border-width:0 5px 5px;border-bottom-color:#000}
 .tooltip.bottom-right .tooltip-arrow{top:0;left:5px;margin-top:-5px;border-width:0 5px 5px;border-bottom-color:#000}
-.popover{position:absolute;top:0;left:0;z-index:1060;display:none;max-width:276px;padding:1px;font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-size:22px;font-weight:400;line-height:1.45454545;text-align:left;background-color:#fff;background-clip:padding-box;border:1px solid #ccc;border:1px solid rgba(0,0,0,.2);border-radius:0;-webkit-box-shadow:0 5px 10px rgba(0,0,0,.2);box-shadow:0 5px 10px rgba(0,0,0,.2);white-space:normal}
+.popover{position:absolute;top:0;left:0;z-index:1060;display:none;max-width:276px;padding:1px;font-family:"Source Sans Pro",Calibri,Candara,Arial,sans-serif;font-size:17px;font-weight:400;line-height:1.41176471;text-align:left;background-color:#fff;background-clip:padding-box;border:1px solid #ccc;border:1px solid rgba(0,0,0,.2);border-radius:0;-webkit-box-shadow:0 5px 10px rgba(0,0,0,.2);box-shadow:0 5px 10px rgba(0,0,0,.2);white-space:normal}
 .popover.top{margin-top:-10px}
 .popover.right{margin-left:10px}
 .popover.bottom{margin-top:10px}
 .popover.left{margin-left:-10px}
-.popover-title{margin:0;padding:8px 14px;font-size:22px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;border-radius:-1 -1 0 0}
+.popover-title{margin:0;padding:8px 14px;font-size:17px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;border-radius:-1 -1 0 0}
 .popover-content{padding:9px 14px}
 .popover>.arrow,.popover>.arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid}
 .popover>.arrow{border-width:11px}
@@ -1408,3 +1408,116 @@ a.list-group-item-warning.active:focus,a.list-group-item-warning.active:hover{ba
 a.list-group-item-danger.active{background-color:#ff0039}
 a.list-group-item-danger.active:focus,a.list-group-item-danger.active:hover{background-color:#e60033}
 .modal .close,.popover{color:#333}
+/* Overrides for larger font size on wider displays below. */
+@media(min-width:600px){body{font-size:22px;line-height:1.45454545}
+.img-thumbnail{line-height:1.45454545}
+hr{margin-top:31px;margin-bottom:31px}
+h1,.h1,h2,.h2,h3,.h3{margin-top:31px;margin-bottom:15.5px}
+h4,.h4,h5,.h5,h6,.h6{margin-top:15.5px;margin-bottom:15.5px}
+h1,.h1{font-size:57px}
+h2,.h2{font-size:47px}
+h3,.h3{font-size:38px}
+h4,.h4{font-size:28px}
+h5,.h5{font-size:22px}
+h6,.h6{font-size:19px}
+p{margin:0 0 15.5px}
+.lead{margin-bottom:31px;font-size:25px}
+}
+@media(min-width:768px){.lead{font-size:33px}
+}
+@media(min-width:600px){small,.small{font-size:86%}
+.page-header{padding-bottom:14.5px;margin:62px 0 31px}
+ul,ol{margin-bottom:15.5px}
+dl{margin-bottom:31px}
+dt,dd{line-height:1.45454545}
+blockquote{padding:15.5px 31px;margin:0 0 31px;font-size:27.5px}
+blockquote footer,blockquote small,blockquote .small{line-height:1.45454545}
+address{margin-bottom:31px;line-height:1.45454545}
+pre{padding:15px;margin:0 0 15.5px;font-size:21px;line-height:1.45454545}
+.table{margin-bottom:31px}
+.table>thead>tr>th,.table>tbody>tr>th,.table>tfoot>tr>th,.table>thead>tr>td,.table>tbody>tr>td,.table>tfoot>tr>td{line-height:1.45454545}
+}
+@media screen and (max-width:767px) and (min-width:600px){.table-responsive{margin-bottom:23.25px}
+}
+@media(min-width:600px){legend{margin-bottom:31px;font-size:33px}
+output{font-size:22px;line-height:1.45454545}
+.form-control{height:53px;font-size:22px;line-height:1.45454545}
+}
+@media screen and (-webkit-min-device-pixel-ratio:0) and (min-width:600px){input[type="date"],input[type="time"],input[type="datetime-local"],input[type="month"]{line-height:53px}
+input[type="date"].input-sm,input[type="time"].input-sm,input[type="datetime-local"].input-sm,input[type="month"].input-sm,.input-group-sm input[type="date"],.input-group-sm input[type="time"],.input-group-sm input[type="datetime-local"],.input-group-sm input[type="month"]{line-height:40px}
+input[type="date"].input-lg,input[type="time"].input-lg,input[type="datetime-local"].input-lg,input[type="month"].input-lg,.input-group-lg input[type="date"],.input-group-lg input[type="time"],.input-group-lg input[type="datetime-local"],.input-group-lg input[type="month"]{line-height:76px}
+}
+@media(min-width:600px){.radio label,.checkbox label{min-height:31px}
+.form-control-static{min-height:53px}
+.input-sm{height:40px;font-size:19px}
+select.input-sm{height:40px;line-height:40px}
+.form-group-sm .form-control{height:40px;font-size:19px}
+select.form-group-sm .form-control{height:40px;line-height:40px}
+.form-group-sm .form-control-static{height:40px;font-size:19px;min-height:50px}
+.input-lg{height:76px;font-size:28px}
+select.input-lg{height:76px;line-height:76px}
+.form-group-lg .form-control{height:76px;font-size:28px}
+select.form-group-lg .form-control{height:76px;line-height:76px}
+.form-group-lg .form-control-static{height:76px;font-size:28px;min-height:59px}
+.has-feedback .form-control{padding-right:66.25px}
+.form-control-feedback{width:53px;height:53px;line-height:53px}
+.input-lg+.form-control-feedback{width:76px;height:76px;line-height:76px}
+.input-sm+.form-control-feedback{width:40px;height:40px;line-height:40px}
+.has-feedback label ~ .form-control-feedback{top:36px}
+.form-horizontal .radio,.form-horizontal .checkbox{min-height:42px}
+.btn{font-size:22px;line-height:1.45454545}
+.btn-lg,.btn-group-lg>.btn{font-size:28px}
+.btn-sm,.btn-group-sm>.btn{font-size:19px}
+.btn-xs,.btn-group-xs>.btn{font-size:19px}
+.dropdown-menu{font-size:22px}
+.dropdown-menu .divider{margin:14.5px 0}
+.dropdown-menu>li>a{line-height:1.45454545}
+.dropdown-header{font-size:19px;line-height:1.45454545}
+.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:76px;font-size:28px}
+select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:76px;line-height:76px}
+.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:40px;font-size:19px}
+select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:40px;line-height:40px}
+.input-group-addon{font-size:22px}
+.input-group-addon.input-sm{font-size:19px}
+.input-group-addon.input-lg{font-size:28px}
+.nav .nav-divider{margin:14.5px 0}
+.nav-tabs>li>a{line-height:1.45454545}
+.navbar{margin-bottom:31px}
+.navbar-brand{padding:9.5px 15px;font-size:28px;line-height:31px}
+/* navbar-nav margin rule overridden later in original Bootswatch. Readded here due to it being a difference between font sizes, so commented out as otherwise it causes the navbar-brand to have the wrong position.
+.navbar-nav{margin: 4.75px -15px}*/
+.navbar-nav>li>a{line-height:31px}
+}
+@media(max-width:767px) and (min-width:600px){.navbar-nav .open .dropdown-menu>li>a{line-height:31px}
+}
+@media(min-width:768px){.navbar-nav>li>a{padding-top:9.5px;padding-bottom:9.5px}
+}
+@media(min-width:600px){.navbar-form{margin-top:-1.5px;margin-bottom:-1.5px}
+.navbar-btn{margin-top:-1.5px;margin-bottom:-1.5px}
+.navbar-btn.btn-sm{margin-top:5px;margin-bottom:5px}
+.navbar-text{margin-top:9.5px;margin-bottom:9.5px}
+.breadcrumb{margin-bottom:31px}
+.pagination{margin:31px 0}
+.pagination>li>a,.pagination>li>span{line-height:1.45454545}
+.pagination-lg>li>a,.pagination-lg>li>span{font-size:28px}
+.pagination-sm>li>a,.pagination-sm>li>span{font-size:19px}
+.pager{margin:31px 0}
+.badge{font-size:19px}
+.jumbotron p{font-size:33px}
+}
+@media screen and (min-width:768px){.jumbotron h1,.jumbotron .h1{font-size:99px}
+}
+@media(min-width:600px){.thumbnail{margin-bottom:31px;line-height:1.45454545}
+.alert{margin-bottom:31px}
+.progress{height:31px;margin-bottom:31px}
+.progress-bar{font-size:19px;line-height:31px}
+.panel{margin-bottom:31px}
+.panel-title{font-size:25px}
+.panel-group{margin-bottom:31px}
+.close{font-size:33px}
+.modal-header{min-height:16.45454545px}
+.modal-title{line-height:1.45454545}
+.tooltip{font-size:19px}
+.popover{font-size:22px;line-height:1.45454545}
+.popover-title{font-size:22px}
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -123,9 +123,18 @@ footer.post-info .label {
 }
 
 /* Make highlighted code sections have paragraph spacing */
-.highlight pre {
-    margin-bottom: 1.294117647em;
-    font-size: 0.772727273em;
+@media (min-width: 600px) {
+    .highlight pre {
+        margin-bottom: 1.294117647em;
+        font-size: 0.772727273em;
+    }
+}
+
+@media (max-width: 599px) {
+    .highlight pre {
+        margin-bottom: 1.307692308em;
+        font-size: 0.764705882em;
+    }
 }
 
 /* Make site name smaller in navbar; we know which site we're on from address bar */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -89,19 +89,37 @@ footer.post-info .label {
     margin-bottom: 1em;
 }
 
-/* Increase header spacing to correspond to base font size and paragraph spacing */
-.entry-content h1,
-.entry-content h2,
-.entry-content h3 {
-    margin-top: 44px;
-    margin-bottom: 22px;
+/* Match header spacing to base font size and paragraph spacing */
+@media (min-width: 600px) {
+    .entry-content h1,
+    .entry-content h2,
+    .entry-content h3 {
+        margin-top: 44px;
+        margin-bottom: 22px;
+    }
+
+    .entry-content h4,
+    .entry-content h5,
+    .entry-content h6 {
+        margin-top: 22px;
+        margin-bottom: 22px;
+    }
 }
 
-.entry-content h4,
-.entry-content h5,
-.entry-content h6 {
-    margin-top: 22px;
-    margin-bottom: 22px;
+@media (max-width: 599px) {
+    .entry-content h1,
+    .entry-content h2,
+    .entry-content h3 {
+        margin-top: 34px;
+        margin-bottom: 17px;
+    }
+
+    .entry-content h4,
+    .entry-content h5,
+    .entry-content h6 {
+        margin-top: 17px;
+        margin-bottom: 17px;
+    }
 }
 
 /* Make highlighted code sections have paragraph spacing */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -8,7 +8,12 @@ body {
     font-stretch: normal;
     text-transform: none;
     font-family: "Source Sans Pro",Calibri,Candara,Arial,sans-serif;
-    font-size: 50px;
+}
+
+@media (min-width: 600px) {
+    #banner h1 {
+        font-size: 50px;
+    }
 }
 
 .footnote {


### PR DESCRIPTION
Fonts were too large on mobile devices with 360px width displays. Target mobile first with 17px font size and then increase this if we are displaying the site on a display with width 600px or more.

The differences between CSS at 17px and 22px were found by diffing them. At least one difference had been overridden in Bootswatch, then got readded as a result of it being one of the differences and appearing later in the CSS. This led to the navbar layout looking worse.

Looking over the site, there doesn't seem to be any other detrimental effect caused.
