### PR TITLE
Remove blue colour from focused pager buttons

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -152,7 +152,8 @@ footer.post-info a,
 footer.post-info a:visited,
 footer.post-info a:hover,
 footer:not(.post-info) a:focus,
-.article-link a:focus {
+.article-link a:focus,
+.pager a:focus {
     color: inherit;
 }
 


### PR DESCRIPTION
Using pager buttons instead of pagination now.

This makes those buttons behave more consistently with the rest of the
index page links.
