### PR TITLE
Remove fix for anchor offset

### DIFF
--- a/pelican-bootstrap3/static/css/style.css
+++ b/pelican-bootstrap3/static/css/style.css
@@ -222,15 +222,16 @@ figure.floatcenter, .align-center {
     }
 }
 
-:target:before {
+
+/*:target:before {
   content:"";
   display:block;
   height:50px;
   /* fixed header height*/
-
+/*
   margin:-50px 0 0;
   /* negative fixed header height */
-}
+/*}*/
 
 .gap-right {
     margin-right: 10px;


### PR DESCRIPTION
This breaks layout of my site, e.g. if you click a footnote link. I
think this fix is for a problem if you don't have a fixed navbar, i.e.
the anchor is behind the navbar.

Was from
getpelican/pelican-themes@4fa865ee2ec2265cf725dbbdd86d0e5e13e155ee.